### PR TITLE
Fetch tx data for v2 transactions and merge with response

### DIFF
--- a/src/common/transactions.ts
+++ b/src/common/transactions.ts
@@ -61,7 +61,7 @@ export default class Transactions {
     const response = await this.api.get(`tx/${id}`);
 
     if (response.status == 200) {
-      if (response.data.format >= 2 && response.data.data_size) {
+      if (response.data.format >= 2 && response.data.data_size > 0) {
         const data = await this.getData(id);
         return new Transaction({
           ...response.data,

--- a/src/common/transactions.ts
+++ b/src/common/transactions.ts
@@ -57,14 +57,26 @@ export default class Transactions {
       });
   }
 
-  public get(id: string): Promise<Transaction> {
-    return this.api.get(`tx/${id}`).then(response => {
-      if (response.status == 200 && response.data && response.data.id == id) {
-        if (response.data.format) {
-          return new Transaction(response.data);
-        }
-        return new Transaction({ ...response.data, format: 1 });
+  public async get(id: string): Promise<Transaction> {
+    const response = await this.api.get(`tx/${id}`);
+
+    if (response.status == 200) {
+      if (
+        response.data.format &&
+        response.data.format == 2 &&
+        response.data.data_size
+      ) {
+        const data = await this.getData(id);
+        return new Transaction({
+          ...response.data,
+          data,
+        });
       }
+      return new Transaction({
+        ...response.data,
+        format: response.data.format || 1,
+      });
+    }
 
       if (response.status == 202) {
         throw new ArweaveError(ArweaveErrorType.TX_PENDING);

--- a/src/common/transactions.ts
+++ b/src/common/transactions.ts
@@ -74,20 +74,19 @@ export default class Transactions {
       });
     }
 
-      if (response.status == 202) {
-        throw new ArweaveError(ArweaveErrorType.TX_PENDING);
-      }
+    if (response.status == 202) {
+      throw new ArweaveError(ArweaveErrorType.TX_PENDING);
+    }
 
-      if (response.status == 404) {
-        throw new ArweaveError(ArweaveErrorType.TX_NOT_FOUND);
-      }
+    if (response.status == 404) {
+      throw new ArweaveError(ArweaveErrorType.TX_NOT_FOUND);
+    }
 
-      if (response.status == 410) {
-        throw new ArweaveError(ArweaveErrorType.TX_FAILED);
-      }
+    if (response.status == 410) {
+      throw new ArweaveError(ArweaveErrorType.TX_FAILED);
+    }
 
-      throw new ArweaveError(ArweaveErrorType.TX_INVALID);
-    });
+    throw new ArweaveError(ArweaveErrorType.TX_INVALID);
   }
 
   public fromRaw(attributes: object): Transaction {

--- a/src/common/transactions.ts
+++ b/src/common/transactions.ts
@@ -61,11 +61,7 @@ export default class Transactions {
     const response = await this.api.get(`tx/${id}`);
 
     if (response.status == 200) {
-      if (
-        response.data.format &&
-        response.data.format == 2 &&
-        response.data.data_size
-      ) {
+      if (response.data.format >= 2 && response.data.data_size) {
         const data = await this.getData(id);
         return new Transaction({
           ...response.data,


### PR DESCRIPTION
This patches a gap left by a backwards incompatible API change, where the data field is now omitted by default so requires an additional call for v2 transactions.