### PR TITLE
use browser field.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "arweave",
   "version": "1.7.1",
   "description": "Arweave JS client library",
-  "main": "index.js",
+  "main": "./node/index.js",
+  "browser": "./web/index.js",
   "files": [
     "node",
     "web",


### PR DESCRIPTION
```ts
import arweave from "arweave";
// in browser use `arweave/web`
// in node use `arweave/node`
```
- in webpack (etc web bundler) first use `browser` field by default
https://docs.npmjs.com/files/package.json#browser
https://webpack.js.org/configuration/resolve/#resolvealiasfields
https://github.com/browserify/browserify-handbook#browser-field
https://github.com/defunctzombie/package-browser-field-spec

- in node use `main` field
https://docs.npmjs.com/files/package.json#main