### PR TITLE
fix: better handling of Buffer & string txs in transactions.post()

### DIFF
--- a/src/common/lib/transaction-uploader.ts
+++ b/src/common/lib/transaction-uploader.ts
@@ -61,6 +61,9 @@ export class TransactionUploader {
     if (!transaction.id) {
       throw new Error(`Transaction is not signed`);
     }
+    if (!transaction.chunks) {
+      throw new Error(`Transaction chunks not prepared`);
+    }
     // Make a copy of transaction, zeroing the data so we can serialize.
     this.data = transaction.data;
     this.transaction = new Transaction(Object.assign({}, transaction, { data: new Uint8Array(0) }));

--- a/src/common/transactions.ts
+++ b/src/common/transactions.ts
@@ -49,7 +49,7 @@ export default class Transactions {
            * return it as a winston string.
            * @param data
            */
-          function(data): string {
+          function(data: any): string {
             return data;
           }
         ]
@@ -204,22 +204,22 @@ export default class Transactions {
     if (typeof transaction === 'string') {
       transaction = new Transaction(JSON.parse(transaction as string))
     }
-    else if (transaction instanceof Buffer) {
+    else if (typeof (transaction as any).readInt32BE === 'function') {
       transaction = new Transaction(JSON.parse(transaction.toString()))
     }
-    else if (typeof transaction === 'object'  && !(transaction instanceof Transaction)) {
-      transaction = new Transaction(transaction);
+    else if (typeof transaction === 'object' && !(transaction instanceof Transaction)) {
+      transaction = new Transaction(transaction as object);
     }
     
     if (!(transaction instanceof Transaction)) {
       throw new Error(`Must be Transaction object`);
     }
 
-    if (transaction.data.byteLength > 1024 * 1024 * 10) {
-      console.warn(`transactions.getUploader() or transactions.upload() is recommended for large data transactions`);
+    if (!transaction.chunks) {
+      await transaction.prepareChunks(transaction.data);
     }
     
-    const uploader = await this.getUploader(transaction as Transaction);
+    const uploader = await this.getUploader(transaction);
     
     // Emulate existing error & return value behaviour.
     try {


### PR DESCRIPTION
This fixes a bug in `transactions.post` when you pass a transaction as a string or Buffer, and the transaction doesn't have any chunks prepared so fails to post. arweave-deploy passes transactions as a Buffer which triggers this.