### PR TITLE
Timestamp commits using Gitstamp

### DIFF
--- a/.github/workflows/gitstamp.yaml
+++ b/.github/workflows/gitstamp.yaml
@@ -1,0 +1,16 @@
+# See: https://github.com/artob/gitstamp-action
+---
+name: Gitstamp
+on: [push]
+jobs:
+  gitstamp:
+    runs-on: ubuntu-latest
+    name: Timestamp commit with Gitstamp
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+      - name: Submit Gitstamp transaction
+        uses: artob/gitstamp-action@v1
+        with:
+          wallet-key: ${{ secrets.GITSTAMP_KEYFILE }}
+          commit-link: true


### PR DESCRIPTION
As discussed on Discord with @jespern, and tested in a [test repository](https://github.com/ArweaveTeam/gitstamp), let's timestamp all commits using [Gitstamp](https://gitstamp.dev).

The Arweave wallet to pay for the transactions has already been set up as an organization secret by @jespern, so no further action is needed beyond merging this PR.