### PR TITLE
fix: support for Angular 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ const arweave = Arweave.init({
 
 ### NPM Web
 ```js
-import Arweave from 'arweave';
+import Arweave from 'arweave/web';
 
 // Since v1.5.1 you're now able to call the init function for the web version without options. The current path will be used by default, recommended.
 const arweave = Arweave.init();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "arweave",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3442,8 +3442,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "npm-run-path": {
       "version": "2.0.2",
@@ -3732,8 +3731,7 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
       "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "pify": {
       "version": "4.0.1",

--- a/src/common/common.ts
+++ b/src/common/common.ts
@@ -43,7 +43,7 @@ export default class Arweave {
 
   public chunks: Chunks;
 
-  public static init: (apiConfig: ApiConfig) => Arweave;
+  public static init: (apiConfig?: ApiConfig) => Arweave;
 
   public static crypto: CryptoInterface;
 

--- a/src/common/lib/crypto/webcrypto-driver.ts
+++ b/src/common/lib/crypto/webcrypto-driver.ts
@@ -50,7 +50,6 @@ export default class WebCryptoDriver implements CryptoInterface {
     data: Uint8Array,
     { saltLength = 0 }: SignatureOptions = {}
   ): Promise<Uint8Array> {
-    console.log(saltLength)
     let signature = await this.driver.sign(
       {
         name: "RSA-PSS",

--- a/src/common/lib/crypto/webcrypto-driver.ts
+++ b/src/common/lib/crypto/webcrypto-driver.ts
@@ -48,7 +48,7 @@ export default class WebCryptoDriver implements CryptoInterface {
   public async sign(
     jwk: JWKInterface,
     data: Uint8Array,
-    { saltLength }: SignatureOptions = {}
+    { saltLength = 0 }: SignatureOptions = {}
   ): Promise<Uint8Array> {
     console.log(saltLength)
     let signature = await this.driver.sign(

--- a/src/common/lib/crypto/webcrypto-driver.ts
+++ b/src/common/lib/crypto/webcrypto-driver.ts
@@ -50,6 +50,7 @@ export default class WebCryptoDriver implements CryptoInterface {
     data: Uint8Array,
     { saltLength }: SignatureOptions = {}
   ): Promise<Uint8Array> {
+    console.log(saltLength)
     let signature = await this.driver.sign(
       {
         name: "RSA-PSS",

--- a/src/web/index.ts
+++ b/src/web/index.ts
@@ -10,7 +10,7 @@ declare global {
 
 Arweave.crypto = new WebCryptoDriver();
 
-Arweave.init = function(apiConfig: ApiConfig = {}): Arweave {
+Arweave.init = function(apiConfig?: ApiConfig): Arweave {
   function getDefaultConfig(): {
     protocol: string;
     host: string;
@@ -59,9 +59,9 @@ Arweave.init = function(apiConfig: ApiConfig = {}): Arweave {
 
   const defaultConfig = getDefaultConfig();
 
-  const protocol = apiConfig.protocol || defaultConfig.protocol;
-  const host = apiConfig.host || defaultConfig.host;
-  const port = apiConfig.port || defaultConfig.port;
+  const protocol = (apiConfig && apiConfig.protocol) || defaultConfig.protocol;
+  const host = (apiConfig && apiConfig.host) || defaultConfig.host;
+  const port = (apiConfig && apiConfig.port) || defaultConfig.port;
 
   return new Arweave({
     ...apiConfig,

--- a/src/web/index.ts
+++ b/src/web/index.ts
@@ -10,7 +10,7 @@ declare global {
 
 Arweave.crypto = new WebCryptoDriver();
 
-Arweave.init = function(apiConfig?: ApiConfig): Arweave {
+Arweave.init = function(apiConfig: ApiConfig = {}): Arweave {
   function getDefaultConfig(): {
     protocol: string;
     host: string;
@@ -59,9 +59,9 @@ Arweave.init = function(apiConfig?: ApiConfig): Arweave {
 
   const defaultConfig = getDefaultConfig();
 
-  const protocol = (apiConfig && apiConfig.protocol) || defaultConfig.protocol;
-  const host = (apiConfig && apiConfig.host) || defaultConfig.host;
-  const port = (apiConfig && apiConfig.port) || defaultConfig.port;
+  const protocol = apiConfig.protocol || defaultConfig.protocol;
+  const host = apiConfig.host || defaultConfig.host;
+  const port = apiConfig.port || defaultConfig.port;
 
   return new Arweave({
     ...apiConfig,


### PR DESCRIPTION
**Changes**

- Changed common.ts init function to receive apiConfig as an optional paramater instead of required;
- Changed webcrypto-driver.ts to give the value 0 as default for saltLength;
- Changed npm web section of documentation to indicate that the import for web is not 'arweave' but 'arweave/web';

Tested in a demo project with Angular 11.