### PR TITLE
Weavemask-compatible `getAddress`

### DIFF
--- a/src/common/wallets.ts
+++ b/src/common/wallets.ts
@@ -58,8 +58,32 @@ export default class Wallets {
     return this.crypto.generateJWK();
   }
 
-  public async jwkToAddress(jwk: JWKInterface): Promise<string> {
-    return this.ownerToAddress(jwk.n);
+  public async jwkToAddress(jwk?: JWKInterface | "use_wallet"): Promise<string> {
+    if(!jwk || jwk === "use_wallet") {
+      return this.getAddress();
+    }
+    else {
+      // @ts-ignore
+      return this.getAddress(jwk.n);
+    }
+  }
+
+  public async getAddress(jwk?: JWKInterface | "use_wallet"): Promise<string> {
+    if(!jwk || jwk === "use_wallet") {
+      try {
+        // @ts-ignore
+        await window.weavemask.connect(["ACCESS_ADDRESS"]);
+      } catch {
+        // Permission is already granted
+      }
+
+      // @ts-ignore
+      return window.weavemask.getActiveAddress();
+
+    }
+    else {
+      return this.ownerToAddress(jwk.n);
+    }
   }
 
   public async ownerToAddress(owner: string): Promise<string> {

--- a/src/common/wallets.ts
+++ b/src/common/wallets.ts
@@ -59,12 +59,11 @@ export default class Wallets {
   }
 
   public async jwkToAddress(jwk?: JWKInterface | "use_wallet"): Promise<string> {
-    if(!jwk || jwk === "use_wallet") {
+    if (!jwk || jwk === "use_wallet") {
       return this.getAddress();
     }
     else {
-      // @ts-ignore
-      return this.getAddress(jwk.n);
+      return this.getAddress(jwk);
     }
   }
 


### PR DESCRIPTION
Introduces a new function -- `getAddress(jwk? | "use_wallet")` which either gets the address from a JWK, or calls the weavemask interface, similarly to @johnletey 's `sign` changes.

This is not tested!!! Please test thoroughly before merging.

We should also add a deprecation notice for `jwkToAddress`, as the the `getAddress` interface should be used in its place. Not sure if we have a standardised way of doing that yet?