### PR TITLE
Type declarations and check permissions for window.arweaveWallet

### DIFF
--- a/src/common/transactions.ts
+++ b/src/common/transactions.ts
@@ -392,6 +392,10 @@ declare global {
       connect(permissions: PermissionType[]): Promise<void>;
     }
   }
+  interface WindowEventMap {
+    walletSwitch: CustomEvent<{ address: string }>;
+    arweaveWalletLoaded: CustomEvent<{}>;
+  }
 }
 
 /**

--- a/src/common/transactions.ts
+++ b/src/common/transactions.ts
@@ -388,7 +388,7 @@ declare global {
   interface Window {
     arweaveWallet: {
       getPermissions(): Promise<PermissionType[]>;
-      sign(transiction: Transaction, options?: SignatureOptions): Promise<Transaction>;
+      sign(transaction: Transaction, options?: SignatureOptions): Promise<Transaction>;
       connect(permissions: PermissionType[]): Promise<void>;
     }
   }

--- a/src/common/transactions.ts
+++ b/src/common/transactions.ts
@@ -194,13 +194,11 @@ export default class Transactions {
       );
     } else if (!jwk || jwk === "use_wallet") {
       try {
-        // @ts-ignore
         await window.arweaveWallet.connect(["SIGN_TRANSACTION"]);
       } catch {
         // Permission is already granted
       }
 
-      // @ts-ignore
       const signedTransaction = await window.arweaveWallet.sign(
         transaction,
         options
@@ -379,3 +377,24 @@ export default class Transactions {
     return uploader;
   }
 }
+
+/**
+ * Arweave wallet declarations
+ */
+declare global {
+  interface Window {
+    arweaveWallet: {
+      getPermissions(): Promise<PermissionType[]>;
+      sign(transiction: Transaction, options?: SignatureOptions): Promise<Transaction>;
+      connect(permissions: PermissionType[]): Promise<void>;
+    }
+  }
+}
+
+/**
+ * Arweave wallet permission types
+ */
+export type PermissionType =
+  | "ACCESS_ADDRESS"
+  | "ACCESS_ALL_ADDRESSES"
+  | "SIGN_TRANSACTION";

--- a/src/common/transactions.ts
+++ b/src/common/transactions.ts
@@ -194,7 +194,10 @@ export default class Transactions {
       );
     } else if (!jwk || jwk === "use_wallet") {
       try {
-        await window.arweaveWallet.connect(["SIGN_TRANSACTION"]);
+        const existingPermissions = await window.arweaveWallet.getPermissions();
+        
+        if(!existingPermissions.includes("SIGN_TRANSACTION"))
+          await window.arweaveWallet.connect(["SIGN_TRANSACTION"]);
       } catch {
         // Permission is already granted
       }


### PR DESCRIPTION
- Add necessary type declarations for `window.arweaveWallet`
- Add check for permissions