### PR TITLE
Resolving "(node:58407) UnhandledPromiseRejectionWarning: TypeError […

### DIFF
--- a/src/common/lib/crypto/node-driver.ts
+++ b/src/common/lib/crypto/node-driver.ts
@@ -53,8 +53,7 @@ export default class NodeCryptoDriver implements CryptoInterface {
           .update(data)
           .sign({
             key: this.jwkToPem(jwk),
-            padding: constants.RSA_PKCS1_PSS_PADDING,
-            saltLength,
+            padding: constants.RSA_PKCS1_PSS_PADDING
           })
       );
     });


### PR DESCRIPTION
…ERR_INVALID_OPT_VALUE]: The value "undefined" is invalid for option "saltLength""

This is probably not the correct solution, but it seems that this function (sign) is often receiving an invalid salt length and causes a failure of the entire arweave / smartweave javascript library.