### PR TITLE
Use pkg for `arweaveWallet` types

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "npm": ">=6.7.0"
   },
   "dependencies": {
+    "arconnect": "^0.2.8",
     "asn1.js": "^5.4.1",
     "axios": "^0.21.1",
     "base64-js": "^1.3.1",

--- a/src/common/transactions.ts
+++ b/src/common/transactions.ts
@@ -11,6 +11,7 @@ import {
   SerializedUploader,
 } from "./lib/transaction-uploader";
 import Chunks from "./chunks";
+import "arconnect";
 
 export interface TransactionConfirmedData {
   block_indep_hash: string;
@@ -386,53 +387,3 @@ export default class Transactions {
     return uploader;
   }
 }
-
-/**
- * Arweave wallet declarations
- */
-declare global {
-  interface Window {
-    arweaveWallet: {
-      connect(permissions: PermissionType[]): Promise<void>;
-      disconnect(): Promise<void>;
-      getActiveAddress(): Promise<string>;
-      getAllAddresses(): Promise<string[]>;
-      getWalletNames(): Promise<{ [addr: string]: string }>;
-      sign(
-        transaction: Transaction,
-        options?: SignatureOptions
-      ): Promise<Transaction>;
-      getPermissions(): Promise<PermissionType[]>;
-      encrypt(
-        data: string,
-        options: {
-          algorithm: string;
-          hash: string;
-          salt?: string;
-        }
-      ): Promise<Uint8Array>;
-      decrypt(
-        data: Uint8Array,
-        options: {
-          algorithm: string;
-          hash: string;
-          salt?: string;
-        }
-      ): Promise<string>;
-    };
-  }
-  interface WindowEventMap {
-    walletSwitch: CustomEvent<{ address: string }>;
-    arweaveWalletLoaded: CustomEvent<{}>;
-  }
-}
-
-/**
- * Arweave wallet permission types
- */
- export type PermissionType =
-  | "ACCESS_ADDRESS"
-  | "ACCESS_ALL_ADDRESSES"
-  | "SIGN_TRANSACTION"
-  | "ENCRYPT"
-  | "DECRYPT";

--- a/src/common/wallets.ts
+++ b/src/common/wallets.ts
@@ -2,6 +2,7 @@ import Api from "./lib/api";
 import CryptoInterface from "./lib/crypto/crypto-interface";
 import { JWKInterface } from "./lib/wallet";
 import * as ArweaveUtils from "./lib/utils";
+import "arconnect";
 
 export default class Wallets {
   private api: Api;

--- a/yarn.lock
+++ b/yarn.lock
@@ -283,6 +283,13 @@ anymatch@~3.1.1:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
+arconnect@^0.2.8:
+  version "0.2.8"
+  resolved "https://registry.yarnpkg.com/arconnect/-/arconnect-0.2.8.tgz#46d86d4e52be1ed69b801ac54e949426fb12ef80"
+  integrity sha512-BGc4em7vMgZyNOI2SlkqFNNosPW0wN2CPs5mImVNWQfjv/WK7XAH6R23ngVCArh2r7NTIAtQYdnVRAID8eXzNw==
+  dependencies:
+    arweave "^1.10.13"
+
 arg@^4.1.0:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
@@ -299,6 +306,16 @@ array-filter@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/array-filter/-/array-filter-1.0.0.tgz#baf79e62e6ef4c2a4c0b831232daffec251f9d83"
   integrity sha1-uveeYubvTCpMC4MSMtr/7CUfnYM=
+
+arweave@^1.10.13:
+  version "1.10.13"
+  resolved "https://registry.yarnpkg.com/arweave/-/arweave-1.10.13.tgz#88205154524b30a22b18f011f7241b2ddc22413c"
+  integrity sha512-FfM9CAF5msAk/12d87KDKu+00/ZriEf/S3ei2FTPMKCOdOb++SwLx7F3kAKO74obAgIGzL8X4Y0D/aV8oNNJDA==
+  dependencies:
+    asn1.js "^5.4.1"
+    axios "^0.21.1"
+    base64-js "^1.3.1"
+    bignumber.js "^9.0.1"
 
 asn1.js@^5.2.0, asn1.js@^5.4.1:
   version "5.4.1"


### PR DESCRIPTION
As @cedriking suggested, we created a package for the `window.arweaveWallet` Object. This pr replaces the locally used ones, so users can safely install that package (https://github.com/th8ta/ArConnect/issues/17).