### PR TITLE
Prepare the transaction chunks to resume uploading

### DIFF
--- a/src/common/lib/transaction-uploader.ts
+++ b/src/common/lib/transaction-uploader.ts
@@ -185,10 +185,14 @@ export class TransactionUploader {
 
     // Everything looks ok, reconstruct the TransactionUpload,
     // prepare the chunks again and verify the data_root matches
+    var transaction = new Transaction(serialized.transaction);
+    if (!transaction.chunks) {
+      await transaction.prepareChunks(data);
+    }
 
     const upload = new TransactionUploader(
       api,
-      new Transaction(serialized.transaction)
+      transaction
     );
 
     // Copy the serialized upload information, and data passed in.
@@ -199,7 +203,7 @@ export class TransactionUploader {
     upload.txPosted = serialized.txPosted;
     upload.data = data;
 
-    await upload.transaction.prepareChunks(data);
+    
 
     if (upload.transaction.data_root !== serialized.transaction.data_root) {
       throw new Error(`Data mismatch: Uploader doesn't match provided data.`);


### PR DESCRIPTION
arweave-js supports resuming chunk uploads by creating an uploader from <txid> and data arguments, however this codepath had a bug in it, preventing the `TransactionUploader` constructor from initializing a new uploader instance. The `TransactionUploader` requires a `Transaction` instance who's chunks have been prepared, this PR prepares the `Transaction` so that the `TransactionUploader` constructor succeeds.

```let uploader = await arweave.transactions.getUploader('hd_dHsvm0FTlCYhkhEqLKcRjuq2fGfRVy2mlIN5I5mQ', data);```

^ This is now the most succinct way to resume an upload for a previously posted transaction, presuming the caller has access to the original data.