### PR TITLE
Support initializing an uploader from a transaction with data

### DIFF
--- a/src/common/transactions.ts
+++ b/src/common/transactions.ts
@@ -321,7 +321,7 @@ export default class Transactions {
    */
   public async getUploader(
     upload: Transaction | SerializedUploader | string,
-    data: Uint8Array | ArrayBuffer
+    data?: Uint8Array | ArrayBuffer
   ) {
     let uploader!: TransactionUploader;
 
@@ -329,11 +329,15 @@ export default class Transactions {
       data = new Uint8Array(data);
     }
 
-    if (!data || !(data instanceof Uint8Array)) {
-      throw new Error(`Must provide data when resuming upload`);
-    }
-
     if (upload instanceof Transaction) {
+      if (!data) {
+        data = upload.data;
+      }
+
+      if(!(data instanceof Uint8Array)){
+        throw new Error("Data format is invalid");
+      }
+
       if (!upload.chunks) {
         await upload.prepareChunks(data);
       }
@@ -346,6 +350,10 @@ export default class Transactions {
     } else {
       if (typeof upload === "string") {
         upload = await TransactionUploader.fromTransactionId(this.api, upload);
+      }
+
+      if (!data || !(data instanceof Uint8Array)) {
+        throw new Error(`Must provide data when resuming upload`);
       }
 
       // upload should be a serialized upload.


### PR DESCRIPTION
This supports main uses cases for `getUploader()`

1. "Golden Path" - uploader from a fully initialized new transaction instance with data.
2. "Resume Path" - uploader from 'txid' and data arguments, or an deserialized transaction instance with data
3. "Resume from Uploader" - uploader from a SerializedUploader instance. 

Note: If the caller attempts 2. and does not provide a data parameter `getUploader()` will throw an error.
"Uncaught Error: Must provide data when resuming upload"
