### PR TITLE
Fix for signing transactions when the data is missing

### DIFF
--- a/src/common/lib/transaction.ts
+++ b/src/common/lib/transaction.ts
@@ -233,7 +233,7 @@ export default class Transaction
           tags,
         ]);
       case 2:
-        await this.prepareChunks(this.data);
+        if (!this.data_root) { await this.prepareChunks(this.data); }
 
         const tagList: [Uint8Array, Uint8Array][] = this.tags.map((tag) => [
           tag.get("name", { decode: true, string: false }),


### PR DESCRIPTION
when the data_root is available, don't call prepareChunks() from the getSignatureData() function

prepareChunks() is called there exclusively to generate the data_root field before signing. However, when the data_root is already generated and the transaction is missing its data (e.g. when sending only the required info for a wallet provider to sign a transaction), calling prepareChunks() deletes the data_root field