### PR TITLE
improved get tx data

### DIFF
--- a/src/common/chunks.ts
+++ b/src/common/chunks.ts
@@ -54,7 +54,10 @@ export default class Chunks {
     let byte = 0;
 
     while (byte < size) {
-      console.log(`[chunk] ${byte}/${size}`);
+      if (this.api.config.logging) {
+        console.log(`[chunk] ${byte}/${size}`);
+      }
+
       let chunkData;
       try {
         chunkData = await this.getChunkData(startOffset + byte);

--- a/src/common/chunks.ts
+++ b/src/common/chunks.ts
@@ -46,7 +46,6 @@ export default class Chunks {
 
   async downloadChunkedData(id: string): Promise<Uint8Array> {
     const offsetResponse = await this.getTransactionOffset(id);
-    console.log({ offsetResponse });
     const size = parseInt(offsetResponse.size);
     const endOffset = parseInt(offsetResponse.offset);
     const startOffset = endOffset - size + 1;

--- a/src/common/lib/crypto/node-driver.ts
+++ b/src/common/lib/crypto/node-driver.ts
@@ -1,9 +1,7 @@
 import { JWKInterface } from "../wallet";
 import CryptoInterface, { SignatureOptions } from "./crypto-interface";
-
+import crypto from "crypto";
 import { pemTojwk, jwkTopem } from "./pem";
-
-import * as crypto from "crypto";
 import * as constants from "constants";
 
 export default class NodeCryptoDriver implements CryptoInterface {

--- a/src/common/lib/transaction-uploader.ts
+++ b/src/common/lib/transaction-uploader.ts
@@ -87,7 +87,7 @@ export class TransactionUploader {
    * itself and on any subsequent calls uploads the
    * next chunk until it completes.
    */
-  public async uploadChunk(): Promise<void> {
+  public async uploadChunk(chunkIndex_?: number): Promise<void> {
     if (this.isComplete) {
       throw new Error(`Upload is already complete`);
     }
@@ -127,7 +127,14 @@ export class TransactionUploader {
       return;
     }
 
-    const chunk = this.transaction.getChunk(this.chunkIndex, this.data);
+    if (chunkIndex_) {
+      this.chunkIndex = chunkIndex_;
+    }
+
+    const chunk = this.transaction.getChunk(
+      chunkIndex_ || this.chunkIndex,
+      this.data
+    );
 
     const chunkOk = await validatePath(
       this.transaction.chunks!.data_root,

--- a/src/modules.d.ts
+++ b/src/modules.d.ts
@@ -1,0 +1,1 @@
+declare module "crypto";

--- a/test/blocks.ts
+++ b/test/blocks.ts
@@ -42,15 +42,4 @@ describe("Blocks", function () {
     // then
     expect(expectedResult).to.deep.equal(result);
   });
-
-  it("should get current block's data", async function () {
-    // given
-    const { current } = await arweave.network.getInfo();
-
-    // when
-    const result = await arweave.blocks.getCurrent();
-
-    // then (account for fast mining rate and forgive it being in previous_block)
-    expect(current).to.be.oneOf([result.previous_block, result.indep_hash]);
-  });
 });

--- a/test/blocks.ts
+++ b/test/blocks.ts
@@ -50,7 +50,7 @@ describe("Blocks", function () {
     // when
     const result = await arweave.blocks.getCurrent();
 
-    // then
-    expect(result.indep_hash).to.be.equal(current);
+    // then (account for fast mining rate and forgive it being in previous_block)
+    expect(current).to.be.oneOf([result.previous_block, result.indep_hash]);
   });
 });

--- a/test/transactions.ts
+++ b/test/transactions.ts
@@ -235,7 +235,7 @@ describe("Transactions", function () {
   });
 
   it("should get transaction data > 12MiB from a gateway", async function () {
-    this.timeout(20000);
+    this.timeout(60000);
     const data = (await arweave.transactions.getData(liveDataTxidLarge, {
       decode: true,
     })) as Uint8Array;

--- a/test/transactions.ts
+++ b/test/transactions.ts
@@ -235,7 +235,7 @@ describe("Transactions", function () {
   });
 
   it("should get transaction data > 12MiB from a gateway", async function () {
-    this.timeout(60000);
+    this.timeout(150000);
     const data = (await arweave.transactions.getData(liveDataTxidLarge, {
       decode: true,
     })) as Uint8Array;

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -14,6 +14,7 @@
         "resolveJsonModule": true,
     },
     "include": [
+        "src/modules.d.ts",
         "src/common",
         "src/node"
     ]

--- a/tsconfig.web.json
+++ b/tsconfig.web.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
+        "esModuleInterop": true,
         "outDir": "./dist/web/",
         "sourceMap": true,
         "strict": true,
@@ -12,6 +13,7 @@
         ],
     },
     "include": [
+        "src/modules.d.ts",
         "src/common",
         "src/web"
     ]


### PR DESCRIPTION
Making it more clear to the user when getTransactionData fails because of missing chunk.
Also adding esModuleInterop to enable default import on the crypto module. The importAsterisk wrapper which tslib generated from ts compilation has been a PITA on numerious occasions for me. The browser output will look like this

``` 
var __importDefault = (this && this.__importDefault) || function (mod) {
    return (mod && mod.__esModule) ? mod : { "default": mod };
};
Object.defineProperty(exports, "__esModule", { value: true });
```

so default will exist if it didn't exist (which it doesn't for crypto-browserify).