### PR TITLE
Remove unused debug function

### DIFF
--- a/src/common/lib/merkle.ts
+++ b/src/common/lib/merkle.ts
@@ -3,7 +3,6 @@
  */
 import Arweave from "../common";
 import { concatBuffers } from "./utils";
-import { inspect } from "util";
 
 export interface Chunk {
   dataHash: Uint8Array;
@@ -375,40 +374,4 @@ export async function validatePath(
   }
 
   return false;
-}
-
-/**
- * Inspect an arweave chunk proof.
- * Takes proof, parses, reads and displays the values for console logging.
- * One proof section per line
- * Format: left,right,offset => hash
- */
-export async function debug(proof: Uint8Array, output = ""): Promise<string> {
-  if (proof.byteLength < 1) {
-    return output;
-  }
-
-  const left = proof.slice(0, HASH_SIZE);
-  const right = proof.slice(left.length, left.length + HASH_SIZE);
-  const offsetBuffer = proof.slice(
-    left.length + right.length,
-    left.length + right.length + NOTE_SIZE
-  );
-  const offset = bufferToInt(offsetBuffer);
-
-  const remainder = proof.slice(
-    left.length + right.length + offsetBuffer.length
-  );
-
-  const pathHash = await hash([
-    await hash(left),
-    await hash(right),
-    await hash(offsetBuffer),
-  ]);
-
-  const updatedOutput = `${output}\n${inspect(Buffer.from(left))},${inspect(
-    Buffer.from(right)
-  )},${offset} => ${inspect(pathHash)}`;
-
-  return debug(remainder, updatedOutput);
 }

--- a/test/chunks.ts
+++ b/test/chunks.ts
@@ -195,19 +195,6 @@ describe("Chunks", function () {
     const rootNode = await generateTree(data);
 
     expect(bufferTob64Url(rootNode.id)).to.equal(rootB64Url);
-    // const sortedProofs = await Promise.all(
-    //   proofs.map(async (item) => {
-    //     return {
-    //       ...item,
-    //       proof: item.proof,
-    //       proofb64: bufferTob64Url(item.proof),
-    //       debug: await debug(item.proof),
-    //     };
-    //   })
-    // );
-    // console.log("Root hash", bufferTob64Url(rootHash));
-    // console.log(inspect(sortedProofs, false, null, true));
-    // const toTest = sortedProofs[0];
   });
 
   it("should build valid proofs from tree", async function () {


### PR DESCRIPTION
It looks like there is an unused `debug` function in the `common` directory which is exported for both browser and Node.js environments. I'd like to propose removing function since it is is not used anywhere in the repository and potentially is problematic for frontend UI apps importing `arweave`.

The unused code can be problematic because it exports `inspect` from [`util`](https://www.npmjs.com/package/util) (a `Node.js` package) to web browser environments. Below are the results of importing `arweave` into a minimal [create-react-app](https://github.com/facebook/create-react-app):

<img width="1268" alt="Screen Shot 2021-12-25 at 7 42 40 PM" src="https://user-images.githubusercontent.com/1811365/147398312-d7a3584e-d399-4cf0-8e3c-4d558faf70a1.png">

Related, `webpack` is unable to bundle browser apps that import `arweave`:

<img width="834" alt="Screen Shot 2021-12-25 at 8 36 10 PM" src="https://user-images.githubusercontent.com/1811365/147398979-49414a18-27c4-4093-8c72-65c8a4e78c19.png">






