### PR TITLE
re-implement getData fallback mechanism

### DIFF
--- a/src/common/lib/merkle.ts
+++ b/src/common/lib/merkle.ts
@@ -59,8 +59,15 @@ export async function chunkData(data: Uint8Array): Promise<Chunk[]> {
     }
 
     const chunk = rest.slice(0, chunkSize);
+    console.log(Arweave);
     const dataHash = await Arweave.crypto.hash(chunk);
+
     cursor += chunk.byteLength;
+    console.log({
+      dataHash,
+      minByteRange: cursor - chunk.byteLength,
+      maxByteRange: cursor,
+    });
     chunks.push({
       dataHash,
       minByteRange: cursor - chunk.byteLength,

--- a/test/silo.ts
+++ b/test/silo.ts
@@ -26,8 +26,6 @@ describe("Silo", function () {
   });
 
   it("should read and write encrypted data", async function () {
-    this.timeout(5000);
-
     const siloURI = "some-secret.1";
 
     const wallet = await arweave.wallets.generate();

--- a/test/transactions.ts
+++ b/test/transactions.ts
@@ -17,7 +17,7 @@ const liveDataTxid = "bNbA3TEQVL60xlgCcqdz4ZPHFZ711cZ3hmkpGttDt_U";
 const liveDataTxidLarge = "KDKSOaecDl_IM4E0_0XiApwdrElvb9TnwOzeHt65Sno";
 
 describe("Transactions", function () {
-  this.timeout(10000);
+  this.timeout(30000);
 
   it("should create and sign data transactions", async function () {
     const wallet = await arweave.wallets.generate();


### PR DESCRIPTION
While this leaves me with bad taste in my mouth.

Because:
 1. users don't have a good way currently to get data by chunks from arweave-js
 2. users don't have a good way to target nodes as opposed to gateways (since nodes don't have /{txid} routes)
 3. users don't have a good way to know if their data is well seeded
 
 that said, the nodes backing up arweave-net gateway can be rotated for maintainance, causing chunks to temorarily to get lost until they are seeded to the other backing nodes. This causes problems with reading smartweave contracts states, so I suggest here instead, to alarm the users damn much about the possibility of data being not present and/or not seeded properly.
 
 I hope this change brings the best of both worlds.