### PR TITLE
Add react-native target, sharing node's entrypoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.11.4",
   "description": "Arweave JS client library",
   "main": "./node/index.js",
+  "react-native": "./node/index.js",
   "browser": "./web/index.js",
   "files": [
     "node",


### PR DESCRIPTION
There are a couple of reasons for this:
1. Web implementations within arweave-js are heavily coupled to web crypto, window namespace etc
2. Node dependencies have better support in the form of native overrides