### PR TITLE
Fix RSA verification for web

### DIFF
--- a/src/common/lib/crypto/webcrypto-driver.ts
+++ b/src/common/lib/crypto/webcrypto-driver.ts
@@ -84,7 +84,7 @@ export default class WebCryptoDriver implements CryptoInterface {
 
     const key = await this.jwkToPublicCryptoKey(publicKey);
 
-    const verifyWith32 = this.driver.verify(
+    const verifyWith32 = await this.driver.verify(
       {
         name: "RSA-PSS",
         saltLength: 32,
@@ -94,7 +94,7 @@ export default class WebCryptoDriver implements CryptoInterface {
       data
     );
 
-    const verifyWith0 = this.driver.verify(
+    const verifyWith0 = await this.driver.verify(
       {
         name: "RSA-PSS",
         saltLength: 0,


### PR DESCRIPTION
Currently return value return verifyWith32 || verifyWith0; == return Promise<boolean> || Promise<boolean> so we get only result for `verifyWith32` only