### PR TITLE
Fetch Adapter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.11.6",
       "license": "MIT",
       "dependencies": {
+        "@vespaiach/axios-fetch-adapter": "^0.3.1",
         "arconnect": "^0.4.2",
         "asn1.js": "^5.4.1",
         "axios": "^0.27.2",
@@ -273,6 +274,14 @@
       "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/@vespaiach/axios-fetch-adapter": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@vespaiach/axios-fetch-adapter/-/axios-fetch-adapter-0.3.1.tgz",
+      "integrity": "sha512-+1F52VWXmQHSRFSv4/H0wtnxfvjRMPK5531e880MIjypPdUSX6QZuoDgEVeCE1vjhzDdxCVX7rOqkub7StEUwQ==",
+      "peerDependencies": {
+        "axios": ">=0.26.0"
+      }
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.11.1",
@@ -4489,6 +4498,12 @@
       "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
       "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
       "dev": true
+    },
+    "@vespaiach/axios-fetch-adapter": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@vespaiach/axios-fetch-adapter/-/axios-fetch-adapter-0.3.1.tgz",
+      "integrity": "sha512-+1F52VWXmQHSRFSv4/H0wtnxfvjRMPK5531e880MIjypPdUSX6QZuoDgEVeCE1vjhzDdxCVX7rOqkub7StEUwQ==",
+      "requires": {}
     },
     "@webassemblyjs/ast": {
       "version": "1.11.1",

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "node": ">=12"
   },
   "dependencies": {
+    "@vespaiach/axios-fetch-adapter": "^0.3.1",
     "arconnect": "^0.4.2",
     "asn1.js": "^5.4.1",
     "axios": "^0.27.2",

--- a/src/common/lib/api.ts
+++ b/src/common/lib/api.ts
@@ -89,7 +89,7 @@ export default class Api {
       timeout: this.config.timeout,
       maxContentLength: 1024 * 1024 * 512,
       headers,
-      adapter: fetchAdapter
+      adapter: (!XMLHttpRequest && fetchAdapter) || undefined
     });
 
     if (this.config.logging) {

--- a/src/common/lib/api.ts
+++ b/src/common/lib/api.ts
@@ -89,7 +89,7 @@ export default class Api {
       timeout: this.config.timeout,
       maxContentLength: 1024 * 1024 * 512,
       headers,
-      adapter: (!XMLHttpRequest && fetchAdapter) || undefined
+      adapter: (!!fetch && fetchAdapter) || undefined
     });
 
     if (this.config.logging) {

--- a/src/common/lib/api.ts
+++ b/src/common/lib/api.ts
@@ -1,3 +1,4 @@
+import fetchAdapter from "@vespaiach/axios-fetch-adapter";
 import Axios, { AxiosResponse, AxiosRequestConfig, AxiosInstance } from "axios";
 
 export interface ApiConfig {
@@ -88,6 +89,7 @@ export default class Api {
       timeout: this.config.timeout,
       maxContentLength: 1024 * 1024 * 512,
       headers,
+      adapter: fetchAdapter
     });
 
     if (this.config.logging) {


### PR DESCRIPTION
- Add `@vespaiach/axios-fetch-adapter` to fix Manifest v3 incompatibility (axios window.XMLHttpRequest undefined)

Closes #184.

Published under `@arconnect/arweave@1.11.6` on npm