### PR TITLE
fix(jwk): add validation for jwks

### DIFF
--- a/src/common/common.ts
+++ b/src/common/common.ts
@@ -85,6 +85,13 @@ export default class Arweave {
     attributes: Partial<CreateTransactionInterface>,
     jwk?: JWKInterface | "use_wallet"
   ): Promise<Transaction> {
+
+    const isValidJWK = jwk && jwk !== "use_wallet" ? await this.validateJWK(jwk) : true;
+
+    if (!isValidJWK) {
+      throw new Error(`The JWK is not valid.`);
+    }
+
     const transaction: Partial<CreateTransactionInterface> = {};
 
     Object.assign(transaction, attributes);
@@ -215,5 +222,14 @@ export default class Arweave {
     return this.api
       .post("/arql", query)
       .then((response) => response.data || []);
+  }
+
+  public async validateJWK(jwk: JWKInterface): Promise<boolean> {
+    const transaction = await this.createTransaction({
+      data: "test",
+    });
+    await this.transactions.sign(transaction, jwk);
+
+    return await this.transactions.verify(transaction);
   }
 }

--- a/test/wallets.ts
+++ b/test/wallets.ts
@@ -99,4 +99,15 @@ describe("Wallets and keys", function () {
       .to.be.a("string")
       .and.equal("fOVzBRTBnyt4VrUUYadBH8yras_-jhgpmNgg-5b3vEw");
   });
+
+  it("should throw on bad JWK", async function () {
+    const jwk = await arweave.wallets.generate();
+    jwk.n = jwk.n.slice(0, -1);
+    try {
+      await arweave.wallets.jwkToAddress(jwk);
+    } catch (e: any) {
+      expect(e).to.be.an("error");
+      expect(e.message).to.equal("The JWK is not valid.");
+    }
+  });
 });


### PR DESCRIPTION
Ran into an issue across multiple apps that pull in the jwk and create an address with invalid jwk.n keys.

This validates the JWK by verifying the signature when signing transactions and when generating a wallet address. Should help prevent people accidentally sending tokens to their wallet when onboarding (as is what happend to me)