### PR TITLE
fix(exports): fix exports for node and web

### DIFF
--- a/src/common/common.ts
+++ b/src/common/common.ts
@@ -217,3 +217,10 @@ export default class Arweave {
       .then((response) => response.data || []);
   }
 }
+
+// abstract class so we can make environment specific implementations
+export abstract class BaseArweave extends Arweave {
+  constructor(apiConfig: ApiConfig = {}) {
+    super(apiConfig);
+  }
+}

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -1,8 +1,21 @@
-import Arweave from "./common";
+import DefaultArweave, { BaseArweave } from "./common";
 import { ApiConfig } from "./lib/api";
 
-Arweave.init = function (apiConfig: ApiConfig = {}): Arweave {
-  return new Arweave(apiConfig);
+class NodeArweave extends BaseArweave {
+  constructor(apiConfig: ApiConfig = {}) {
+    super(apiConfig);
+  }
+
+  public static init(apiConfig: ApiConfig = {}): NodeArweave {
+    return new NodeArweave(apiConfig);
+  }
+}
+
+// making it backwards compatible
+DefaultArweave.init = NodeArweave.init;
+
+export {
+  DefaultArweave as Arweave,
+  NodeArweave,
 };
 
-export = Arweave;

--- a/src/web/index.ts
+++ b/src/web/index.ts
@@ -1,4 +1,4 @@
-import Arweave from "./common";
+import DefaultArweave, { BaseArweave } from "./common";
 import { ApiConfig } from "./lib/api";
 import { getDefaultConfig } from "./net-config";
 
@@ -11,8 +11,13 @@ declare global {
   }
 }
 
-Arweave.init = function (apiConfig: ApiConfig = {}): Arweave {
-  const defaults = {
+export class WebArweave extends BaseArweave {
+  constructor(apiConfig: ApiConfig = {}) {
+    super(apiConfig);
+  }
+
+  public static init(apiConfig: ApiConfig = {}): WebArweave {
+    const defaults = {
     host: "arweave.net",
     port: 443,
     protocol: "https",
@@ -23,7 +28,7 @@ Arweave.init = function (apiConfig: ApiConfig = {}): Arweave {
     !location.protocol ||
     !location.hostname
   ) {
-    return new Arweave({
+    return new WebArweave({
       ...apiConfig,
       ...defaults,
     });
@@ -44,19 +49,22 @@ Arweave.init = function (apiConfig: ApiConfig = {}): Arweave {
   const host = apiConfig.host || defaultConfig.host;
   const port = apiConfig.port || defaultConfig.port || locationPort;
 
-  return new Arweave({
-    ...apiConfig,
-    host,
-    protocol,
-    port,
-  });
-};
-
-if (typeof globalThis === "object") {
-  globalThis.Arweave = Arweave;
-} else if (typeof self === "object") {
-  self.Arweave = Arweave;
+    return new WebArweave({
+       ...apiConfig,
+      host,
+      protocol,
+      port,
+    });
+  }
 }
 
+if (typeof globalThis === "object") {
+  globalThis.Arweave = WebArweave;
+} else if (typeof self === "object") {
+  self.Arweave = WebArweave;
+}
+
+// for backwards compatibility
+DefaultArweave.init = WebArweave.init;
 export * from "./common";
-export default Arweave;
+export default DefaultArweave;


### PR DESCRIPTION
Allows for the imports of enviornment specific arweave modules

```typescript
import { NodeArweave } from 'arweave/node';
import { WebArweave } from 'arweave/web';
```