### PR TITLE
fix: use saltLength param when signing (WebCrypto driver)

### DIFF
--- a/src/common/lib/crypto/webcrypto-driver.ts
+++ b/src/common/lib/crypto/webcrypto-driver.ts
@@ -53,7 +53,7 @@ export default class WebCryptoDriver implements CryptoInterface {
     let signature = await this.driver.sign(
       {
         name: "RSA-PSS",
-        saltLength: 32,
+        saltLength: saltLength ?? 32,
       },
       await this.jwkToCryptoKey(jwk),
       data


### PR DESCRIPTION
The WebCrypto driver did not use the passed optional SignatureOptions for saltLength and was hardcoded to 32. This did not match behavior to the Node driver which does utilize the passed-in param. As a result, code written for Node would get different results for signing than WebCrypto when a saltLength of 0 was passed-in (useful for creating predictable signature for a dataitem). 

This PR fixes WebCrypto to behave as Node driver does when saltLength is passed-in. It does, however, default to 32 when no param is given, for the sake of backward compatibility. 